### PR TITLE
Revert "feat: :sparkles: replace rootOrderItems to searchRootOrderIte…

### DIFF
--- a/src/components/common/template/board/board.tsx
+++ b/src/components/common/template/board/board.tsx
@@ -46,7 +46,6 @@ export default function BoardTemplate(props: BoardTemplateProps) {
   const router = useRouter();
 
   const [filter, setFilter] = useState<Record<string, unknown>>(defaultFilter);
-  const [query, setQuery] = useState(null);
 
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(defaultPageSize);
@@ -62,16 +61,7 @@ export default function BoardTemplate(props: BoardTemplateProps) {
       limit: pageSize,
     },
     filter,
-    ...(query ? { query } : {}),
   });
-
-  const handleFilterChange = (newFilter: Record<string, unknown>) => {
-    /** query 필드는 filter에서 제외한다. */
-    setQuery(newFilter.query ?? null);
-    delete newFilter.query;
-
-    setFilter(newFilter);
-  };
 
   if (!data && !loading) {
     return null;
@@ -87,7 +77,7 @@ export default function BoardTemplate(props: BoardTemplateProps) {
       {!!filterInputs && (
         <BoardFilter
           defaultFilter={filter}
-          onFilterChange={handleFilterChange}
+          onFilterChange={setFilter}
           inputs={filterInputs}
         />
       )}

--- a/src/components/common/template/board/board.type.ts
+++ b/src/components/common/template/board/board.type.ts
@@ -9,15 +9,7 @@ import { ColumnsType } from 'antd/lib/table';
 export type BoardDataFetcher<
   DataType = object,
   FilterType = Record<string, unknown>
-> = ({
-  pageInput,
-  filter,
-  query,
-}: {
-  pageInput: PageInput;
-  filter?: FilterType;
-  query?: string;
-}) => {
+> = ({ pageInput, filter }: { pageInput: PageInput; filter?: FilterType }) => {
   data: DataType[];
   total: number;
   loading: boolean;

--- a/src/components/order-item-list/filter/inputs.tsx
+++ b/src/components/order-item-list/filter/inputs.tsx
@@ -7,7 +7,7 @@ import ClaimStatusSelect from './claim-status';
 
 export const orderItemsFilterInputs: BoardFilterInputType[] = [
   {
-    name: 'query',
+    name: 'search',
     label: '검색어',
     Component: Input,
   },


### PR DESCRIPTION
…ms (#18)"

This reverts commit aefb3bf2cb5812f25dad329f36e91f652eb72450.

searchRootOrderItem에 버그가 있어 임시 배포를 위한 브랜치입니다.